### PR TITLE
use_gpu option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Compiled files
+__pycache__/
+*.py[co]
+
+# Other generated files
+htmlcov
+.coverage
+
+# iPython
+.ipynb_checkpoints
+
+# Packages/installer info
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+var
+sdist
+develop-eggs
+.installed.cfg
+distribute-*.tar.gz
+
+# Other
+.*.swp
+*~
+.vscode
+.env
+

--- a/py/nearly_nmf/nmf.py
+++ b/py/nearly_nmf/nmf.py
@@ -344,9 +344,9 @@ def fit_NMF(X: npt.ArrayLike, V: npt.ArrayLike, H_start: npt.ArrayLike = None,
         flips the dimensions for all input arrays. Defaults to False.
     use_gpu : bool, optional
         If True, use GPU even if input X and V are numpy arrays on CPU.
-        If False, use CPU even if input X and V are cupy arrays on GPU.
         By default (None), auto-derive whether to use GPU based upon
         numpy vs. cupy type of input X and V.
+        use_gpu=False with cupy inputs is not supported.
 
     Returns
     -------
@@ -531,12 +531,8 @@ class NMF:
             self.W = xp.asarray(self.rng.uniform(0, 2, W_shape))
             if transpose: self.W = self.W.T
 
-        # Internally store which fitting function we'll be using since the
-        # object initialization has done sanity checking.
-        # self.fit_NMF = shift_NMF if algorithm == "shift" else nearly_NMF
-
+        # Options to pass to fit_NMF
         self.algorithm = algorithm
-
         self.return_chi_2 = return_chi_2
         self.verbose = verbose
 

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -1,0 +1,144 @@
+import unittest
+
+import numpy as np
+from nearly_nmf import nmf
+
+try:
+    import cupy as cp
+    gpu_available = cp.is_available()
+except ImportError:
+    cp = None
+    gpu_available = False
+
+class TestGPU(unittest.TestCase):
+    """
+    Test GPU vs. CPU
+    """
+    def setUp(self):
+        self.rng = np.random.default_rng(100921)
+
+        self.nobs = 100
+        self.nvar = 20
+        self.nvec = 5
+        self.X = self.rng.uniform(1,2, size=(self.nvar, self.nobs))
+        self.V = self.rng.uniform(1,2, size=self.X.shape)
+
+        self.H0 = self.rng.uniform(1,2, size=(self.nvec, self.nobs))
+        self.W0 = self.rng.uniform(1,2, size=(self.nvar, self.nvec))
+
+    @unittest.skipUnless(gpu_available, "requires a GPU")
+    def test_get_array_module(self):
+        cpu_data = np.arange(5)
+        gpu_data = cp.arange(5)
+
+        self.assertIsInstance(cpu_data, np.ndarray)
+        self.assertIsInstance(gpu_data, cp.ndarray)
+        self.assertEqual(nmf._get_array_module(cpu_data), np)
+        self.assertEqual(nmf._get_array_module(gpu_data), cp)
+        self.assertEqual(nmf._get_array_module(cpu_data, use_gpu=True), cp)
+        self.assertEqual(nmf._get_array_module(cpu_data, use_gpu=False), np)
+        self.assertEqual(nmf._get_array_module(gpu_data, use_gpu=True), cp)
+        self.assertEqual(nmf._get_array_module(gpu_data, use_gpu=False), np)
+
+    @unittest.skipUnless(gpu_available, "requires a GPU")
+    def test_nmf(self):
+        """
+        Test consistency of CPU and GPU
+        """
+        #- CPU
+        H, W = nmf.fit_NMF(self.X, self.V,
+                           H_start=self.H0, W_start=self.W0,
+                           n_iter=10)
+        #- GPU
+        Hg, Wg = nmf.fit_NMF(cp.array(self.X), cp.array(self.V),
+                           H_start=self.H0, W_start=self.W0,
+                           n_iter=10)
+
+        #- Get GPU data back to CPU for comparisons
+        Hgx = Hg.get()
+        Wgx = Wg.get()
+
+        self.assertTrue(np.allclose(H, Hgx))
+        self.assertTrue(np.allclose(W, Wgx))
+
+    @unittest.skipUnless(gpu_available, "requires a GPU")
+    def test_nmf_gpu_option(self):
+        """
+        Test forcing GPU or not
+        """
+        for algorithm in ('shift', 'nearly'):
+            #- Auto-derive CPU
+            H, W = nmf.fit_NMF(self.X, self.V,
+                               H_start=self.H0, W_start=self.W0,
+                               n_iter=10, algorithm=algorithm)
+
+            self.assertIsInstance(H, np.ndarray)
+            self.assertIsInstance(W, np.ndarray)
+
+            #- Auto-derive GPU
+            Hg, Wg = nmf.fit_NMF(cp.array(self.X), cp.array(self.V),
+                               n_iter=10, algorithm=algorithm)
+
+            self.assertIsInstance(Hg, cp.ndarray)
+            self.assertIsInstance(Wg, cp.ndarray)
+
+            #- force CPU vs. GPU, but output type should match input type
+
+            #- Force GPU even if input is CPU
+            H, W = nmf.fit_NMF(self.X, self.V,
+                               H_start=self.H0, W_start=self.W0,
+                               n_iter=10, algorithm=algorithm, use_gpu=True)
+
+            self.assertIsInstance(H, np.ndarray)
+            self.assertIsInstance(W, np.ndarray)
+
+            #- Force CPU/GPU to match what input already is, is ok
+
+            H, W = nmf.fit_NMF(self.X, self.V,
+                               H_start=self.H0, W_start=self.W0,
+                               n_iter=10, algorithm=algorithm, use_gpu=False)
+
+            self.assertIsInstance(H, np.ndarray)
+            self.assertIsInstance(W, np.ndarray)
+
+            H, W = nmf.fit_NMF(cp.array(self.X), cp.array(self.V),
+                               H_start=cp.array(self.H0),
+                               W_start=cp.array(self.W0),
+                               n_iter=10, algorithm=algorithm, use_gpu=True)
+
+            self.assertIsInstance(H, cp.ndarray)
+            self.assertIsInstance(W, cp.ndarray)
+
+            #- But forcing CPU when inputs are GPU is not supported
+            with self.assertRaises(TypeError):
+                H, W = nmf.fit_NMF(cp.array(self.X), cp.array(self.V),
+                                   H_start=cp.array(self.H0),
+                                   W_start=cp.array(self.W0),
+                                   n_iter=10, algorithm=algorithm,
+                                   use_gpu=False)
+
+    @unittest.skipUnless(gpu_available, "requires a GPU")
+    def test_object(self):
+        blat = nmf.NMF(self.X, self.V)
+        blat.fit()
+        self.assertIsInstance(blat.H, np.ndarray)
+        self.assertIsInstance(blat.W, np.ndarray)
+
+        blat = nmf.NMF(cp.asarray(self.X), cp.asarray(self.V))
+        blat.fit()
+        self.assertIsInstance(blat.H, cp.ndarray)
+        self.assertIsInstance(blat.W, cp.ndarray)
+
+        blat = nmf.NMF(self.X, self.V, use_gpu=True)
+        blat.fit()
+        self.assertIsInstance(blat.H, np.ndarray)
+        self.assertIsInstance(blat.W, np.ndarray)
+
+        blat = nmf.NMF(self.X, self.V, H_start=self.H0, W_start=self.W0,
+                       use_gpu=True)
+        blat.fit()
+        self.assertIsInstance(blat.H, np.ndarray)
+        self.assertIsInstance(blat.W, np.ndarray)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds a `fit_NMF(X, V, use_gpu=None/True/False)` option as a convenience to use a GPU even if the inputs `X` and `V` are numpy arrays on the CPU.  None will auto-derive what to do based upon input types (default); True will transfer to/from the GPU as needed; False is ok if inputs are numpy but raises and error if inputs are cupy (i.e. we won't copy cupy data back to the CPU to calculate there, which presumably you wouldn't want to do anyway).

Arguably the option could have been called `force_gpu`, but that seems aggressive and is more irritating to type.  Feedback welcome.

This also adds a .gitignore and unit tests to check consistency of CPU and GPU calculations and the `use_gpu` option for both `fit_NMF` and the `NMF` object wrapper.